### PR TITLE
fix errors in exiobase hybrid biosphere mapping

### DIFF
--- a/bw_migrations/data/exiobase-3-ecoinvent-3.6.json
+++ b/bw_migrations/data/exiobase-3-ecoinvent-3.6.json
@@ -624,7 +624,9 @@
         "unit": "kilogram",
         "__multiplier__": 1000,
         "name": "Suspended solids, unspecified",
-        "categories": ["water"]
+        "categories": [
+          "water"
+        ]
       }
     ],
     [
@@ -1246,6 +1248,11 @@
       "title": "Chris Mutel",
       "email": "cmutel@gmail.com",
       "path": "https://chris.mutel.org/",
+      "role": "author"
+    },
+    {
+      "title": "Benjamin W. Portner",
+      "email": "benjamin.portner@bauhaus-luftfahrt.net",
       "role": "author"
     }
   ],

--- a/bw_migrations/data/exiobase-3-ecoinvent-3.6.json
+++ b/bw_migrations/data/exiobase-3-ecoinvent-3.6.json
@@ -17,17 +17,6 @@
     ],
     [
       [
-        "Aldrin",
-        "air"
-      ],
-      {
-        "unit": "kilogram",
-        "__multiplier__": 1000,
-        "name": "Aldrin"
-      }
-    ],
-    [
-      [
         "As",
         "air"
       ],
@@ -44,7 +33,8 @@
       ],
       {
         "unit": "kilogram",
-        "__multiplier__": 1000
+        "__multiplier__": 1000,
+        "name": "Benzene"
       }
     ],
     [
@@ -199,17 +189,6 @@
         "unit": "kilogram",
         "__multiplier__": 1000,
         "name": "Cadmium"
-      }
-    ],
-    [
-      [
-        "Chlordane",
-        "air"
-      ],
-      {
-        "unit": "kilogram",
-        "__multiplier__": 1000,
-        "name": "Chlordane"
       }
     ],
     [
@@ -888,7 +867,7 @@
           "unit": "kilogram",
           "categories": [
             "natural resource",
-            "in ground"
+            "biotic"
           ],
           "__multiplier__": 1000,
           "__disaggregation__": 0.5,
@@ -898,7 +877,7 @@
           "unit": "kilogram",
           "categories": [
             "natural resource",
-            "in ground"
+            "biotic"
           ],
           "__multiplier__": 1000,
           "__disaggregation__": 0.5,
@@ -1030,12 +1009,12 @@
         null
       ],
       {
-        "unit": "kilogram",
+        "unit": "cubic meter",
         "categories": [
           "natural resource",
           "in ground"
         ],
-        "__multiplier__": 1000,
+        "__multiplier__": 1470,
         "name": "Gas, natural, in ground"
       }
     ],
@@ -1045,12 +1024,12 @@
         null
       ],
       {
-        "unit": "kilogram",
+        "unit": "cubic meter",
         "categories": [
           "natural resource",
           "in ground"
         ],
-        "__multiplier__": 1000,
+        "__multiplier__": 1470,
         "name": "Gas, natural, in ground"
       }
     ],
@@ -1063,7 +1042,7 @@
         "unit": "kilogram",
         "categories": [
           "natural resource",
-          "in ground"
+          "biotic"
         ],
         "__multiplier__": 1000,
         "name": "Peat, in ground"
@@ -1153,10 +1132,10 @@
         "unit": "kilogram",
         "categories": [
           "natural resource",
-          "in ground"
+          "in air"
         ],
         "__multiplier__": 1000,
-        "name": "Carbon dioxide, non-fossil"
+        "name": "Carbon dioxide, in air"
       }
     ],
     [
@@ -1165,7 +1144,7 @@
         null
       ],
       {
-        "unit": "kilogram",
+        "unit": "cubic meter",
         "categories": [
           "natural resource",
           "in water"
@@ -1271,6 +1250,7 @@
     }
   ],
   "missing flows": [
+    "Aldrin, air",
     "Aquatic plants",
     "Building stones",
     "C",


### PR DESCRIPTION
- aldrin to air does not exist in ecoinvent biosphere (only to soil)
- dict for benzene was missing name key
- chlordane does not exist in ecoinvent biosphere
- fish is biotic resource, not ground
- natural gas unit is cubis meters in ecoinvent, not kilogram. used density of 0.68 kg/Sm3 for conversion
- peat is biotic resource
- carbon dioxide in air maps to carbon dioxide in air
- water consumption is measured in cubic meters in ecoinvent biosphere